### PR TITLE
CLIMATE_SCHEMA was deprecated in 2025.05 and removed in 2025.11

### DIFF
--- a/components/hisense/climate.py
+++ b/components/hisense/climate.py
@@ -23,10 +23,29 @@ AirConditioner = hisense_ac_ns.class_(
 CONF_HISENSE_ID = "hisense_id"
 
 
-CONFIG_SCHEMA = cv.All(
-    climate.CLIMATE_SCHEMA.extend(
+# ESPHome API migration:
+#   - CLIMATE_SCHEMA was deprecated in 2025.05 and removed in 2025.11.
+#   - The new helper `climate.climate_schema(<Class>)` replaces it and also
+#     auto-generates the component ID, so the explicit
+#     `cv.GenerateID(): cv.declare_id(AirConditioner)` entry is no longer
+#     required (and would actually collide with the auto-generated one).
+#
+# The try/except keeps the component buildable on older ESPHome releases too
+# (anything prior to 2025.11 where `climate_schema` did not yet exist).
+try:
+    _BASE_CLIMATE_SCHEMA = climate.climate_schema(AirConditioner)
+except AttributeError:
+    # Fallback for ESPHome < 2025.11
+    _BASE_CLIMATE_SCHEMA = climate.CLIMATE_SCHEMA.extend(
         {
             cv.GenerateID(): cv.declare_id(AirConditioner),
+        }
+    )
+
+
+CONFIG_SCHEMA = cv.All(
+    _BASE_CLIMATE_SCHEMA.extend(
+        {
             cv.Optional(CONF_FLOW_CONTROL_PIN): pins.gpio_output_pin_schema,
         }
     )


### PR DESCRIPTION
ESPHome API migration:
#   - CLIMATE_SCHEMA was deprecated in 2025.05 and removed in 2025.11.
#   - The new helper `climate.climate_schema(<Class>)` replaces it and also
#     auto-generates the component ID, so the explicit
#     `cv.GenerateID(): cv.declare_id(AirConditioner)` entry is no longer
#     required (and would actually collide with the auto-generated one).